### PR TITLE
Fix wand length field name

### DIFF
--- a/src/main/java/com/java/harrypotter/encyclopedia/entities/Wand.java
+++ b/src/main/java/com/java/harrypotter/encyclopedia/entities/Wand.java
@@ -7,5 +7,5 @@ public class Wand {
 
     private String wood;
     private String core;
-    private Integer lenght;
+    private Integer length;
 }


### PR DESCRIPTION
## Summary
- fix typo in `Wand` entity field name

## Testing
- `sh mvnw -q test` *(fails: `mvnw: 109: cannot open mvnw/.mvn/wrapper/maven-wrapper.properties: No such file`)*

------
https://chatgpt.com/codex/tasks/task_e_686d7574a06c8329ae192606b85813b9